### PR TITLE
tempfix: tracking directions issue

### DIFF
--- a/src/js/rappid.js
+++ b/src/js/rappid.js
@@ -190,7 +190,7 @@ Rappid.prototype = {
         window.analytics.page({
             name: routeDirection,
             route: this.route().id,
-            direction: this.direction().id,
+            //direction: this.direction().id,
             location: {
                 latitude: this.latlng.lat,
                 longitude: this.latlng.lng,


### PR DESCRIPTION
I getting this error in chrome :frowning: 
`Potentially unhandled rejection [2] TypeError: Illegal invocation`

I think the issue is `this.direction().id` in rappid.js. Maybe it's undefined? here's a temporary fix
