### PR TITLE
Fix SVG on Chrome for Android

### DIFF
--- a/src/js/models/Vehicle.js
+++ b/src/js/models/Vehicle.js
@@ -40,7 +40,7 @@ function Vehicle(data) {
 
     // computeds
     this.inServiceReadable = ko.computed(function() { return this.inService() ? "In Service": "Not In Service"; }.bind(this));
-    this.svgTransform = ko.computed(function() { return "scale(1.5) rotate(" + this.heading() + " 15 15)"; }.bind(this));
+    this.svgTransform = ko.computed(function() { return "rotate(" + this.heading() + " 15 15)"; }.bind(this));
 
     this.marker = this.newMarker();
 }
@@ -99,8 +99,8 @@ Vehicle.prototype = {
         this.rotate();
     },
     rotate: function() {
-        var g = this.marker._icon.querySelector('g');
-        g.setAttribute("transform", this.svgTransform());
+        var path = this.marker._icon.querySelector('g .Arrow');
+        path.setAttribute("transform", this.svgTransform());
     },
     remove: function(layer) {
         layer.removeLayer(this.marker);

--- a/src/js/templates/vehicle-marker.svg
+++ b/src/js/templates/vehicle-marker.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg class="vehicle-icon-svg"  width="45px" height="45px" viewBox="0 0 45 45" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
     <defs></defs>
-    <g transform="{svg-transform}" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+    <g transform="scale(1.5)" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
        <circle id="Oval-1" stroke="#E1E1E1" opacity="0.95" fill="#FFFFFF" sketch:type="MSShapeGroup" cx="15" cy="15" r="15"></circle>
-        <path d="M15,5 L22,23.6666667 L15,19 L15,5 L15,5 Z M15,5 L8,23.6666667 L15,19 L15,5 L15,5 Z" id="Shape" fill="rgb(28,161,250)" sketch:type="MSShapeGroup"></path>
+        <path transform="{svg-transform}" d="M15,5 L22,23.6666667 L15,19 L15,5 L15,5 Z M15,5 L8,23.6666667 L15,19 L15,5 L15,5 Z" class="Arrow" fill="rgb(28,161,250)" sketch:type="MSShapeGroup"></path>
         <mask id="mask-2" sketch:name="Path 2" fill="white">
             <use xlink:href="#path-1"></use>
         </mask>


### PR DESCRIPTION
Fixes #146.

![correct svg](http://cl.ly/image/0j1d3q031u1V/svgandroid.png) 
