### PR TITLE
added a theme color tag that sets the address bar color and app bar colo...

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -7,6 +7,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="google-site-verification" content="HQOHLFvHUp-RViUr7Tdf3yG9VcPnnCuJXCofJS0nCKg" />
+    <meta name="theme-color" content="#ffffff">
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="apple-touch-icon" href="img/icon-60.png">
     <link rel="apple-touch-icon" sizes="76x76" href="img/icon-76.png">


### PR DESCRIPTION
...r in

Lollipop Overview for Chrome for Android.  See the link for details.

http://www.androidpolice.com/2014/11/10/chrome-v39-on-lollipop-supports-custom-multitasking-headerstatus-bar-colors-with-a-simple-html-tag/

Sadly I realized that white is the only color that works for now, so
this change effectively does nothing for the time being.  Mayhaps Android
Maple Syrup will change the skin for Overview and the white will stand
out?
