### PR TITLE
Pass HTTPS URL to YQL, remove technical issues notice

### DIFF
--- a/src/js/models/StopDetails.js
+++ b/src/js/models/StopDetails.js
@@ -23,7 +23,7 @@ function StopDetails(routeID, directionID, stopID) {
 StopDetails.prototype.fetch = function() {
     var deferred = when.defer();
     var yqlURL = 'http://query.yahooapis.com/v1/public/yql';
-    var capURL = 'http://www.capmetro.org/planner/s_nextbus2.asp?stopid=' + this.stopID() + '&route=' + this.routeID();
+    var capURL = 'https://www.capmetro.org/planner/s_nextbus2.asp?stopid=' + this.stopID() + '&route=' + this.routeID();
     var params = {
         q: 'select * from xml where url="' + capURL + '"',
         format: 'json'

--- a/src/js/templates/routes-list.html
+++ b/src/js/templates/routes-list.html
@@ -1,10 +1,4 @@
 <div class="shitty-inner">
-    <h3>News</h3>
-
-    <ul class="routes-list inner">
-        <li>CapMetro is having technical issues, arrival times may not appear on a stop.</li>
-    </ul>
-
     <h3>Original Routes</h3>
 
     <ul class="routes-list inner" data-bind="foreach: originalRoutes">


### PR DESCRIPTION
YQL rejects HTTP URLs now (surprise!), so pass HTTPS.