### PR TITLE
Replace YQL with proxy on App Engine

### DIFF
--- a/src/js/models/StopDetails.js
+++ b/src/js/models/StopDetails.js
@@ -32,7 +32,6 @@ StopDetails.prototype.fetch = function() {
 
     function retryAtMost(maxRetries) {
         requests.get(proxyURL, params)
-            // .then(this.parseResponse.bind(this))
             .tap(function(res) {
                 if (res.runs.length > 0) {
                     this.tripCollection = new TripCollection(this.stopID(), this.routeID(), res.runs);

--- a/src/js/models/Trip.js
+++ b/src/js/models/Trip.js
@@ -5,8 +5,6 @@ function Trip(data) {
     this.tripTime = ko.observable(data.estimated_time);
     this.id = ko.observable(data.trip_id);
     this.block = ko.observable(data.block);
-    // this.exception = ko.observable(data.Exception);
-
     this.moment = ko.computed(function() { return moment(this.tripTime(), 'hh:mm A'); }.bind(this));
     this.prettyHour = ko.computed(function() {
         return this.moment().format('h:mm');

--- a/src/js/models/Trip.js
+++ b/src/js/models/Trip.js
@@ -2,10 +2,10 @@ var ko = require('knockout');
 var moment = require('moment');
 
 function Trip(data) {
-    this.tripTime = ko.observable(data.Estimatedtime);
-    this.id = ko.observable(data.Tripid);
-    this.block = ko.observable(data.Block);
-    this.exception = ko.observable(data.Exception);
+    this.tripTime = ko.observable(data.estimated_time);
+    this.id = ko.observable(data.trip_id);
+    this.block = ko.observable(data.block);
+    // this.exception = ko.observable(data.Exception);
 
     this.moment = ko.computed(function() { return moment(this.tripTime(), 'hh:mm A'); }.bind(this));
     this.prettyHour = ko.computed(function() {

--- a/src/js/models/TripCollection.js
+++ b/src/js/models/TripCollection.js
@@ -5,17 +5,17 @@ var config = require('../config');
 var Trip = require('./Trip');
 
 
-function TripCollection(stopID, routeID, Runs) {
+function TripCollection(stopID, routeID, runs) {
     this.stopID = ko.observable(stopID);
     this.routeID = ko.observable(routeID);
-    this.sign = ko.observable(Runs[0].Sign);
+    this.sign = ko.observable(runs[0].sign);
 
-    this.trips = ko.observableArray(this.parseTrips(Runs));
+    this.trips = ko.observableArray(this.parseTrips(runs));
 }
 
-TripCollection.prototype.parseTrips = function(Runs) {
-    var trips = Runs.map(function(Run) {
-        return new Trip(Run);
+TripCollection.prototype.parseTrips = function(runs) {
+    var trips = runs.map(function(run) {
+        return new Trip(run);
     });
 
     // show only the most recent missed trip


### PR DESCRIPTION
YQL has been unreliable, which means we aren't able to show arrival times. Instabus without arrival times is pretty useless. I wrote a simple [proxy](https://gist.github.com/scascketta/cd3ded829de4a67b5a66) on App Engine that gets around SOP and converts the XML to JSON from the nextbus endpoint.