### PR TITLE
Fix null TypeError when trips are unavailable

### DIFF
--- a/src/js/models/StopDetails.js
+++ b/src/js/models/StopDetails.js
@@ -33,7 +33,7 @@ StopDetails.prototype.fetch = function() {
     function retryAtMost(maxRetries) {
         requests.get(proxyURL, params)
             .tap(function(res) {
-                if (res.runs.length > 0) {
+                if (res.runs && res.runs.length > 0) {
                     this.tripCollection = new TripCollection(this.stopID(), this.routeID(), res.runs);
                 }
                 else {


### PR DESCRIPTION
When no trips are available, the runs from instaql is null, so check for that.