### PR TITLE
Filter vehicles by missing position or ID

### DIFF
--- a/src/js/models/Vehicle.js
+++ b/src/js/models/Vehicle.js
@@ -69,9 +69,12 @@ function obaResponseAsTurd(tripDetails, fullRes) {
     var time = moment(tripStatus.lastUpdateTime);
     var updatetime = prettyTime(time) + ' ago';
 
+    var location = tripStatus.lastKnownLocation ? [tripStatus.lastKnownLocation.lat, tripStatus.lastKnownLocation.lon] : [null, null];
+    location = (predictions && location) ?  [tripStatus.position.lat, tripStatus.position.lon] : location;
+
     return {
         vehicleid: tripStatus.vehicleId,
-        location: !predictions ? [tripStatus.lastKnownLocation.lat, tripStatus.lastKnownLocation.lon] : [tripStatus.position.lat, tripStatus.position.lon],
+        location: location,
         routeid: route.shortName,
         direction: directionForHeadsign(trip.tripHeadsign),
         updatetime: updatetime,

--- a/src/js/models/VehicleCollection.js
+++ b/src/js/models/VehicleCollection.js
@@ -19,25 +19,28 @@ function VehicleCollection(route, direction) {
 VehicleCollection.prototype = {
     refresh: function() {
         return this.fetch()
+            .then(this.filter.bind(this))
             .tap(this.draw.bind(this));
     },
     fetch: function() {
         var url = 'https://crossorigin.me/http://52.88.82.199:8080/onebusaway-api-webapp/api/where/trips-for-route/1_' + this.route + '.json?key=TEST&includeSchedules=true&includeStatus=true';
 
         return requests.get(url)
-            .then(this.parseResponse.bind(this, this.direction));
+            .then(this.parseResponse.bind(this));
     },
-    parseResponse: function(direction, res) {
+    parseResponse: function(res) {
         var vehicles = [];
 
         vehicles = res.data.list.map(function(v) {
-            var vehicle = new Vehicle(v, res);
-            // if (vehicle.directionID() === direction) {
-                return vehicle;
-            // }
+            return new Vehicle(v, res);
         });
 
         return vehicles;
+    },
+    filter: function(rawVehicles) {
+        return rawVehicles.filter(function(v) {
+            return v.vehicleID && v.location;
+        });
     },
     draw: function(newVehicles) {
         var addedVehicles = [],


### PR DESCRIPTION
Fixes missing vehicles due to missing positions from OBA. Also filters invalid vehicle positions if they don't have a vehicle ID.

Decided not to use OBA's position predictions based on schedule even if the known location is missing unless explictly specified.